### PR TITLE
Rumble/01/typescript/deno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # vendor/
 public/
 resources/_gen/
+
+.DS_Store

--- a/src/01/typescript/deno/Dockerfile
+++ b/src/01/typescript/deno/Dockerfile
@@ -1,0 +1,14 @@
+FROM hayd/alpine-deno:1.9.2
+
+EXPOSE 3000
+
+WORKDIR /app
+
+USER deno
+
+# These steps will be re-run upon each file change in your working directory:
+ADD . .
+# Compile the main app so that it doesn't need to be compiled each startup/entry.
+RUN deno cache server.ts
+
+CMD ["run", "--allow-net", "server.ts"]

--- a/src/01/typescript/deno/README.md
+++ b/src/01/typescript/deno/README.md
@@ -1,0 +1,9 @@
+# Start:
+
+```
+docker build -t app . && docker run -it --init -p 3000:3000 app
+```
+
+# Gothas 
+- default timeout is set to 30 secs [at the moment deno does not support configuration of this]
+- tested on MBP 13" 2021 with M1 Silicon (arm)

--- a/src/01/typescript/deno/server.ts
+++ b/src/01/typescript/deno/server.ts
@@ -1,0 +1,28 @@
+import {
+  listenAndServe,
+  ServerRequest,
+} from "https://deno.land/std@0.95.0/http/server.ts";
+
+console.log("server is running...");
+
+listenAndServe(
+  { hostname: "0.0.0.0", port: 3000 },
+  async (req: ServerRequest) => {
+    let body = "Use /hello URI\n";
+    
+    if (req.url == "/hello") {
+      body = "Hello\n";
+    }
+    
+    console.log("\x1b[35m", req.method, "\x1b[32m", req.url, "\x1b[37m", req.headers.get("user-agent"));
+
+    const headers = new Headers();
+    headers.set("Content-Type", "text/plain");
+    headers.set("Connection", "keep-alive");
+    req.respond({
+      status: 200,
+      body,
+      headers
+    });
+  }
+);


### PR DESCRIPTION
# Start

```
docker build -t app . && docker run -it --init -p 3000:3000 app
```

# Gothas 
- default timeout is set to 30 secs [at the moment deno does not support configuration of this]
- tested on MBP 13" 2021 with M1 Silicon (arm)

# Preview
![image](https://user-images.githubusercontent.com/1891508/116809855-a76b0f00-ab40-11eb-9a65-53e9786c53df.png)

![image](https://user-images.githubusercontent.com/1891508/116809882-cc5f8200-ab40-11eb-8654-51e8131e7a04.png)

![image](https://user-images.githubusercontent.com/1891508/116809894-dc776180-ab40-11eb-8f1e-24270567268b.png)

![image](https://user-images.githubusercontent.com/1891508/116809899-e4370600-ab40-11eb-8c1e-207e333eaf89.png)
